### PR TITLE
Fix link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ This repository is designed to hold all public issues around the [Broadleaf Comm
 
 ## Other places to get help
 
-Chat with us on [Gitter](https://gitter.im/BroadleafCommerce/BroadleafCommerce), open a question on [Stack Overflow](stackoverflow.com/questions/tagged/broadleaf-commerce) or start a discussion on our [Google Group](https://groups.google.com/forum/#!forum/broadleaf-commerce).
+Chat with us on [Gitter](https://gitter.im/BroadleafCommerce/BroadleafCommerce), open a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/broadleaf-commerce) or start a discussion on our [Google Group](https://groups.google.com/forum/#!forum/broadleaf-commerce).
 
 Those with a support agreement can send us issues via support@broadleafcommerce.com.


### PR DESCRIPTION
The link pointed to https://github.com/BroadleafCommerce/Issues/blob/master/stackoverflow.com/questions/tagged/broadleaf-commerce